### PR TITLE
feat: do not overwrite spark session version

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -115,9 +115,6 @@ class SparkSession private(
    * @since 2.0.0
    */
   def version: String = {
-    // Add by 4paradigm to print library version
-    openmldbSession.version()
-
     SPARK_VERSION
   }
 


### PR DESCRIPTION
* Do not overwrite `version()` 
* Avoid recursively call of `version()` and stack over flow exception